### PR TITLE
feat/components/Header

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,19 @@
+<style lang="scss">
+#app {
+    font-family: Avenir, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-align: center;
+    color: #2c3e50;
+}
+</style>
+
 <template>
     <div id="app">
         <Header />
-        <router-view />
+        <main>
+            <router-view />
+        </main>
     </div>
 </template>
 
@@ -14,13 +26,3 @@ export default {
     },
 };
 </script>
-
-<style lang="scss">
-#app {
-    font-family: Avenir, Helvetica, Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-align: center;
-    color: #2c3e50;
-}
-</style>

--- a/src/api/userWrapper.js
+++ b/src/api/userWrapper.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import User from '../models/user.js';
 
 export default class UserWrapper {
-    constructor () {
+    constructor() {
         this.url = 'https://jsonplaceholder.typicode.com';
     }
 

--- a/src/api/userWrapper.js
+++ b/src/api/userWrapper.js
@@ -2,8 +2,9 @@ import axios from 'axios';
 import User from '../models/user.js';
 
 export default class UserWrapper {
-    url = 'https://jsonplaceholder.typicode.com';
-    constructor() {}
+    constructor () {
+        this.url = 'https://jsonplaceholder.typicode.com';
+    }
 
     async getById(id) {
         try {

--- a/src/assets/images/logo.svg
+++ b/src/assets/images/logo.svg
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="165 50 400 300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.5;">
-    <rect x="336.397" y="241.193" width="76.653" height="53.147"/>
-    <g transform="matrix(1,0,0,1,-1,0)">
-        <path d="M375.767,222.464L375.767,325.313" style="fill:none;stroke:black;stroke-width:5.5px;"/>
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="isolation:isolate" viewBox="0 0 45.034 68.204">
+    <g id="Group">
+        <rect x="0" y="11.003" width="45.034" height="31.224" transform="matrix(1,0,0,1,0,0)" fill="rgb(0,0,0)"/>
+        <line x1="22.542" y1="0" x2="22.542" y2="60.424" vector-effect="non-scaling-stroke" stroke-width="3.231" stroke="rgb(0,0,0)" stroke-linejoin="round" stroke-linecap="butt" stroke-miterlimit="1.5"/>
+        <rect x="15.948" y="8.486" width="13.503" height="6.096" transform="matrix(1,0,0,1,0,0)" fill="rgb(0,0,0)" vector-effect="non-scaling-stroke" stroke-width="0.588" stroke="rgb(0,0,0)" stroke-linejoin="round" stroke-linecap="butt" stroke-miterlimit="1.5"/>
+        <rect x="3.783" y="34.168" width="37.773" height="10.225" transform="matrix(1,0,0,1,0,0)" fill="rgb(0,0,0)"/>
+        <path d=" M 1.083 67.851 L 11.391 42.822 L 14.506 42.556 L 3.71 67.91 L 1.083 67.851 Z " fill-rule="evenodd" fill="rgb(0,0,0)" vector-effect="non-scaling-stroke" stroke-width="0.588" stroke="rgb(0,0,0)" stroke-linejoin="round" stroke-linecap="butt" stroke-miterlimit="1.5"/>
+        <path d=" M 31.301 42.849 L 41.843 67.359 L 44.669 67.377 L 33.996 42.581 L 31.301 42.849 Z " fill-rule="evenodd" fill="rgb(0,0,0)" vector-effect="non-scaling-stroke" stroke-width="0.588" stroke="rgb(0,0,0)" stroke-linejoin="round" stroke-linecap="butt" stroke-miterlimit="1.5"/>
+        <rect x="2.56" y="12.982" width="40.228" height="27.001" transform="matrix(1,0,0,1,0,0)" fill="rgb(255,255,255)" vector-effect="non-scaling-stroke" stroke-width="0.588" stroke="rgb(0,0,0)" stroke-linejoin="round" stroke-linecap="butt" stroke-miterlimit="1.5"/>
+        <path d=" M 4.917 15.374 L 4.917 36.882 L 9.254 36.882 L 11.603 15.404 L 4.917 15.374 Z " fill-rule="evenodd" fill="rgb(0,199,255)"/>
+        <path d=" M 14.376 15.474 L 20.681 15.474 L 21.908 37.108 L 11.786 37.016 L 14.376 15.474 Z " fill-rule="evenodd" fill="rgb(255,236,0)"/>
+        <path d=" M 23.685 15.582 L 29.508 15.582 L 35.617 36.927 L 24.543 37.114 L 23.685 15.582 Z " fill-rule="evenodd" fill="rgb(255,135,0)"/>
+        <path d=" M 32.199 15.62 L 40.298 15.626 L 40.392 36.877 L 38.155 36.833 L 32.199 15.62 Z " fill-rule="evenodd" fill="rgb(121,214,76)"/>
     </g>
-    <rect x="363.542" y="236.908" width="22.984" height="10.376" style="stroke:black;stroke-width:1px;"/>
-    <rect x="342.836" y="280.623" width="64.295" height="17.405"/>
-    <g transform="matrix(1.06109,0,0,1.02292,-21.9752,-6.5278)">
-        <path d="M339.477,336.765L356.012,295.117L361.01,294.673L343.691,336.863L339.477,336.765Z" style="stroke:black;stroke-width:0.96px;"/>
-    </g>
-    <path d="M389.675,295.399L407.619,337.118L412.429,337.149L394.263,294.942L389.675,295.399Z" style="stroke:black;stroke-width:1px;"/>
-    <rect x="340.755" y="244.561" width="68.474" height="45.96" style="fill:white;stroke:black;stroke-width:1px;"/>
-    <path d="M344.766,248.632L344.766,285.242L352.149,285.242L356.146,248.684L344.766,248.632Z" style="fill:rgb(0,199,255);"/>
-    <path d="M360.867,248.802L371.598,248.802L373.687,285.626L356.459,285.47L360.867,248.802Z" style="fill:rgb(255,236,0);"/>
-    <path d="M376.712,248.986L386.624,248.986L397.022,285.318L378.173,285.637L376.712,248.986Z" style="fill:rgb(255,135,0);"/>
-    <path d="M391.204,249.052L404.99,249.062L405.15,285.234L401.342,285.158L391.204,249.052Z" style="fill:rgb(121,214,76);"/>
 </svg>

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -2,10 +2,12 @@
 .drawing-tools {
     @extend .level;
     @extend .is-mobile;
-    background-color: $link;
+    width: 100%;
     height: 4rem;
+    position: absolute;
+    top: 5rem;
     color: $white;
-
+    background-color: $link;
     button {
         @extend .button;
         @extend .level-item;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,14 +1,47 @@
 <style scoped lang="scss">
 header {
-    // position: absolute;
+    min-height: 5rem;
+    box-shadow: 2px 2px 2px 2px hsl(171deg 89% 35%);
 }
 </style>
 
 <template>
     <header>
-        <router-link to="/signup"><p>signup</p></router-link>
-        <router-link to="/login"><p>login</p></router-link>
-        <router-link to="/drawing"><p>drawing</p></router-link>
+        <nav class="navbar" role="navigation" aria-label="main navigation">
+            <div class="navbar-brand">
+                <router-link to="/" class="navbar-item">
+                    <img src="../assets/images/logo.svg" class="m-3" />
+                    <h3 class="page-title title" style="width:200px">Etch A Sketch</h3>
+                </router-link>
+
+                <a
+                    role="button"
+                    class="navbar-burger"
+                    aria-label="menu"
+                    aria-expanded="false"
+                    data-target="navbarBasicExample"
+                >
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                </a>
+            </div>
+
+            <div id="navbarBasicExample" class="navbar-menu">
+                <div class="navbar-start">
+                    <router-link to="/drawing" class="navbar-item">drawing</router-link>
+                </div>
+
+                <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="buttons">
+                            <router-link to="/signup" class="button is-primary">signup</router-link>
+                            <router-link to="/login" class="button is-light">login</router-link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
     </header>
 </template>
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -11,7 +11,7 @@ header {
             <div class="navbar-brand">
                 <router-link to="/" class="navbar-item">
                     <img src="../assets/images/logo.svg" class="m-3" />
-                    <h3 class="page-title title" style="width:200px">Etch A Sketch</h3>
+                    <h3 class="page-title title" style="width: 200px">Etch A Sketch</h3>
                 </router-link>
 
                 <a

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -23,7 +23,8 @@ header {
                     class="navbar-burger"
                     aria-label="menu"
                     aria-expanded="false"
-                    data-target="navbarBasicExample"
+                    data-target="header-nav-items"
+                    @click="isOpenMenu = !isOpenMenu"
                 >
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -31,20 +32,22 @@ header {
                 </a>
             </div>
 
-            <div id="navbarBasicExample" class="navbar-menu">
+            <div 
+                id="header-nav-items"
+                class="navbar-menu"
+                :class="{'is-active': isOpenMenu}"
+            >
                 <div class="navbar-start">
                     <router-link to="/drawing" class="navbar-item sub-title">Drawing</router-link>
                 </div>
 
                 <div class="navbar-end">
-                    <div class="navbar-item">
-                        <div v-if="doesUserSignedIn" class="buttons">
-                            <button to="/" class="button">Logout</button>
-                        </div>
-                        <div v-else class="buttons">
-                            <router-link to="/signup" class="button is-primary">Signup</router-link>
-                            <router-link to="/login" class="button is-light">Login</router-link>
-                        </div>
+                    <div v-if="doesUserSignedIn">
+                        <button to="/" class="button navbar-item">Logout</button>
+                    </div>
+                    <div v-else :class="{buttons: !isOpenMenu}">
+                        <router-link to="/signup" class="button is-primary navbar-item">Signup</router-link>
+                        <router-link to="/login" class="button is-light navbar-item" >Login</router-link>
                     </div>
                 </div>
                 <button @click="doesUserSignedIn = !doesUserSignedIn">Toggle</button>
@@ -59,6 +62,7 @@ export default {
     name: 'Header',
     data() {
         return {
+            isOpenMenu: false,
             doesUserSignedIn: false,
             demoUser: null
         };
@@ -66,6 +70,6 @@ export default {
     mounted(){
         new UserWrapper().getById(1)
             .then(user => this.demoUser = user)
-    }
+    },
 };
 </script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -42,12 +42,18 @@ header {
                         <button to="/" class="button navbar-item">Logout</button>
                     </div>
                     <div v-else :class="{ buttons: !isOpenMenu }">
-                        <router-link to="/signup" class="button is-primary navbar-item"
-                            >Signup</router-link
+                        <router-link 
+                            to="/signup" 
+                            class="button is-primary navbar-item"
                         >
-                        <router-link to="/login" class="button is-light navbar-item"
-                            >Login</router-link
+                            Signup
+                        </router-link>
+                        <router-link
+                            to="/login" 
+                            class="button is-light navbar-item"
                         >
+                            Login
+                        </router-link>
                     </div>
                 </div>
                 <button @click="doesUserSignedIn = !doesUserSignedIn">Toggle</button>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,6 +1,11 @@
 <style scoped lang="scss">
 header {
+    background-color: $white;
+    width: 100%;
     min-height: 5rem;
+    position: absolute;
+    top:0;
+    box-shadow: $shadow;
 }
 </style>
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,6 @@
 <style scoped lang="scss">
 header {
     min-height: 5rem;
-    box-shadow: 2px 2px 2px 2px hsl(171deg 89% 35%);
 }
 </style>
 
@@ -34,22 +33,34 @@ header {
 
                 <div class="navbar-end">
                     <div class="navbar-item">
-                        <div class="buttons">
+                        <div v-if="doesUserSignedIn" class="buttons">
+                            <button to="/" class="button">logout</button>
+                        </div>
+                        <div v-else class="buttons">
                             <router-link to="/signup" class="button is-primary">signup</router-link>
                             <router-link to="/login" class="button is-light">login</router-link>
                         </div>
                     </div>
                 </div>
+                <button @click="doesUserSignedIn = !doesUserSignedIn">Toggle</button>
             </div>
         </nav>
     </header>
 </template>
 
 <script>
+import UserWrapper from '../api/userWrapper'
 export default {
     name: 'Header',
     data() {
-        return {};
+        return {
+            doesUserSignedIn: false,
+            demoUser: null
+        };
     },
+    mounted(){
+        new UserWrapper().getById(1)
+            .then(user => this.demoUser = user)
+    }
 };
 </script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -28,17 +28,17 @@ header {
 
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-start">
-                    <router-link to="/drawing" class="navbar-item">drawing</router-link>
+                    <router-link to="/drawing" class="navbar-item sub-title">Drawing</router-link>
                 </div>
 
                 <div class="navbar-end">
                     <div class="navbar-item">
                         <div v-if="doesUserSignedIn" class="buttons">
-                            <button to="/" class="button">logout</button>
+                            <button to="/" class="button">Logout</button>
                         </div>
                         <div v-else class="buttons">
-                            <router-link to="/signup" class="button is-primary">signup</router-link>
-                            <router-link to="/login" class="button is-light">login</router-link>
+                            <router-link to="/signup" class="button is-primary">Signup</router-link>
+                            <router-link to="/login" class="button is-light">Login</router-link>
                         </div>
                     </div>
                 </div>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,7 +4,7 @@ header {
     width: 100%;
     min-height: 5rem;
     position: absolute;
-    top:0;
+    top: 0;
     box-shadow: $shadow;
 }
 </style>
@@ -32,11 +32,7 @@ header {
                 </a>
             </div>
 
-            <div 
-                id="header-nav-items"
-                class="navbar-menu"
-                :class="{'is-active': isOpenMenu}"
-            >
+            <div id="header-nav-items" class="navbar-menu" :class="{ 'is-active': isOpenMenu }">
                 <div class="navbar-start">
                     <router-link to="/drawing" class="navbar-item sub-title">Drawing</router-link>
                 </div>
@@ -45,9 +41,13 @@ header {
                     <div v-if="doesUserSignedIn">
                         <button to="/" class="button navbar-item">Logout</button>
                     </div>
-                    <div v-else :class="{buttons: !isOpenMenu}">
-                        <router-link to="/signup" class="button is-primary navbar-item">Signup</router-link>
-                        <router-link to="/login" class="button is-light navbar-item" >Login</router-link>
+                    <div v-else :class="{ buttons: !isOpenMenu }">
+                        <router-link to="/signup" class="button is-primary navbar-item"
+                            >Signup</router-link
+                        >
+                        <router-link to="/login" class="button is-light navbar-item"
+                            >Login</router-link
+                        >
                     </div>
                 </div>
                 <button @click="doesUserSignedIn = !doesUserSignedIn">Toggle</button>
@@ -57,19 +57,18 @@ header {
 </template>
 
 <script>
-import UserWrapper from '../api/userWrapper'
+import UserWrapper from '../api/userWrapper';
 export default {
     name: 'Header',
     data() {
         return {
             isOpenMenu: false,
             doesUserSignedIn: false,
-            demoUser: null
+            demoUser: null,
         };
     },
-    mounted(){
-        new UserWrapper().getById(1)
-            .then(user => this.demoUser = user)
+    mounted() {
+        new UserWrapper().getById(1).then((user) => (this.demoUser = user));
     },
 };
 </script>

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -33,7 +33,7 @@
 </style>
 
 <template>
-    <div class="drawing-container">
+    <section class="drawing-container is-fullheight">
         <DrawingTools />
         <div class="body">
             <div class="canvas-container">
@@ -51,7 +51,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </section>
 </template>
 
 <script>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,3 +1,22 @@
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Lobster&display=swap');
+.page-title {
+    font-family: 'Lobster', cursive;
+}
+.box {
+    box-shadow: 2px 2px 2px 2px hsl(171, 89%, 35%);
+}
+.link {
+    color: rgb(6, 69, 173);
+}
+.logo {
+    height: 200px;
+}
+.vertical-align {
+    margin-bottom: auto;
+}
+</style>
+
 <template>
     <section class="hero is-primary is-fullheight">
         <div class="hero-body">
@@ -73,22 +92,3 @@ export default {
     },
 };
 </script>
-
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Lobster&display=swap');
-.page-title {
-    font-family: 'Lobster', cursive;
-}
-.box {
-    box-shadow: 2px 2px 2px 2px hsl(171, 89%, 35%);
-}
-.link {
-    color: rgb(6, 69, 173);
-}
-.logo {
-    height: 200px;
-}
-.vertical-align {
-    margin-bottom: auto;
-}
-</style>

--- a/src/pages/NotFound.vue
+++ b/src/pages/NotFound.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="post">
+    <section class="page">
         <h1>404 Not Found</h1>
-    </div>
+    </section>
 </template>

--- a/src/pages/SignUp.vue
+++ b/src/pages/SignUp.vue
@@ -1,3 +1,22 @@
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Lobster&display=swap');
+.page-title {
+    font-family: 'Lobster', cursive;
+}
+.box {
+    box-shadow: 2px 2px 2px 2px hsl(171, 89%, 35%);
+}
+.link {
+    color: rgb(6, 69, 173);
+}
+.logo {
+    height: 200px;
+}
+.vertical-align {
+    margin-bottom: auto;
+}
+</style>
+
 <template>
     <section class="hero is-primary is-fullheight">
         <div class="hero-body">
@@ -73,22 +92,3 @@ export default {
     },
 };
 </script>
-
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Lobster&display=swap');
-.page-title {
-    font-family: 'Lobster', cursive;
-}
-.box {
-    box-shadow: 2px 2px 2px 2px hsl(171, 89%, 35%);
-}
-.link {
-    color: rgb(6, 69, 173);
-}
-.logo {
-    height: 200px;
-}
-.vertical-align {
-    margin-bottom: auto;
-}
-</style>


### PR DESCRIPTION
#20 
![sshot](https://user-images.githubusercontent.com/72016706/150577810-efc7f0aa-628a-46df-85c8-6fbbbae05914.png)

ヘッダーが必要になったので急遽作成しました。
レイアウトの作成のみが終わっています


### これからやること
- [x] それぞれのページのheightの修正
- [x] ログイン時、ログアウト時の見た目の作成/条件分岐

### 困っていること
Loginフォームの部分みたいにヘッダーに影をつけたいのですが、なぜかcssが効かないです。header内のnavにつけて見るとうまくいくんですが、ちょっとモヤモヤしてます。
Loginページにインナーシャドウをつけるのが最終手段になるかもです。
