### PR TITLE
Feat/drawing/weight color

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -177,6 +177,7 @@ export default {
             this.setNewLine();
             if (this.itemList.length == 0) return;
             this.itemStack.push(this.itemList.pop());
+            if(this.itemList.length==0) return;
             const newPoint = this.itemList[this.itemList.length - 1].lastPoint;
             this.pointer.x = newPoint.x;
             this.pointer.y = newPoint.y;

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -32,7 +32,7 @@ let canvasHeight = 500;
 
 export default {
     name: 'Drawing',
-    props: ['newWeight','newColor'],
+    props: ['newWeight', 'newColor'],
     data() {
         return {
             lineList: [],
@@ -83,10 +83,10 @@ export default {
             this.lineConfig.weight = newWeight;
             this.pointer.radius = newWeight / 2;
         },
-        newColor: function(){
-            this.lineConfig.color=this.newColor;
-            this.pointer.stroke=this.newColor;
-        }
+        newColor: function () {
+            this.lineConfig.color = this.newColor;
+            this.pointer.stroke = this.newColor;
+        },
     },
     methods: {
         keyEvent(event, boolean) {

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -63,10 +63,7 @@ export default {
         };
     },
     mounted: function () {
-        this.direction.isUp = false;
-        this.direction.isDown = false;
-        this.direction.isRight = false;
-        this.direction.isLeft = false;
+        this.stopPointer();
         document.addEventListener('keydown', this.keyDown);
         document.addEventListener('keyup', this.keyUp);
         this.timer = setInterval(this.draw, 15);
@@ -81,13 +78,21 @@ export default {
             let newWeight = Number(this.newWeight);
             this.lineConfig.weight = newWeight;
             this.pointer.radius = newWeight / 2;
+            this.lineConfig.newLineFlag = true;
         },
         newColor: function () {
             this.lineConfig.color = this.newColor;
             this.pointer.stroke = this.newColor;
+            this.lineConfig.newLineFlag = true;
         },
     },
     methods: {
+        stopPointer(){
+            this.direction.isUp = false;
+            this.direction.isDown = false;
+            this.direction.isRight = false;
+            this.direction.isLeft = false;
+        },
         keyEvent(event, boolean) {
             let key = event.key;
             if (key in keyMap) {

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -32,7 +32,7 @@ let canvasHeight = 500;
 
 export default {
     name: 'Drawing',
-    props: ['newWeight'],
+    props: ['newWeight','newColor'],
     data() {
         return {
             lineList: [],
@@ -83,6 +83,10 @@ export default {
             this.lineConfig.weight = newWeight;
             this.pointer.radius = newWeight / 2;
         },
+        newColor: function(){
+            this.lineConfig.color=this.newColor;
+            this.pointer.stroke=this.newColor;
+        }
     },
     methods: {
         keyEvent(event, boolean) {

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -32,6 +32,7 @@ let canvasHeight = 500;
 
 export default {
     name: 'Drawing',
+    props: ['newWeight'],
     data() {
         return {
             lineList: [],
@@ -45,7 +46,7 @@ export default {
                 radius: 3,
                 fill: 'white',
                 stroke: 'black',
-                strokeWidth: 2,
+                strokeWidth: 4,
             },
             lineConfig: {
                 color: 'black',
@@ -75,6 +76,13 @@ export default {
         document.removeEventListener('keydown', this.keyDown);
         document.removeEventListener('keyup', this.keyUp);
         clearInterval(this.timer);
+    },
+    watch: {
+        newWeight: function () {
+            let newWeight = Number(this.newWeight);
+            this.lineConfig.weight = newWeight;
+            this.pointer.radius = newWeight / 2;
+        },
     },
     methods: {
         keyEvent(event, boolean) {

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -106,7 +106,7 @@ export default {
         },
     },
     methods: {
-        stopPointer(){
+        stopPointer() {
             this.direction.isUp = false;
             this.direction.isDown = false;
             this.direction.isRight = false;
@@ -177,7 +177,7 @@ export default {
             this.setNewLine();
             if (this.itemList.length == 0) return;
             this.itemStack.push(this.itemList.pop());
-            if(this.itemList.length==0) return;
+            if (this.itemList.length == 0) return;
             const newPoint = this.itemList[this.itemList.length - 1].lastPoint;
             this.pointer.x = newPoint.x;
             this.pointer.y = newPoint.y;

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -69,7 +69,12 @@
                 <div class="background-circle" :style="{ backgroundColor: color }">
                     <font-awesome-icon class="awesome-icon zindex-2" icon="palette" />
                 </div>
-                <input class="color-picker" type="color" v-model="color" @change="$emit('change-color', color)" />
+                <input
+                    class="color-picker"
+                    type="color"
+                    v-model="color"
+                    @change="$emit('change-color', color)"
+                />
             </button>
             <div
                 class="dropdown"

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -85,7 +85,13 @@
                     <div class="dropdown-content">
                         <div class="dropdown-item">
                             weight: {{ weight }} px
-                            <input type="range" min="1" max="200" v-model="weight" />
+                            <input
+                                type="range"
+                                min="2"
+                                max="20"
+                                v-model="weight"
+                                @change="$emit('change-weight', weight)"
+                            />
                         </div>
                     </div>
                 </div>
@@ -149,7 +155,7 @@ export default {
                 others: false,
             },
             color: '#000000',
-            weight: 50,
+            weight: 3,
         };
     },
 };

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -81,8 +81,13 @@ $width__sidebar: 20em;
                         <a>
                             <div class="columns is-vcentered">
                                 <div class="column">
-                                    <input type="color" v-model="color" class="color-picker" @click="$emit('click-color-picker')"
-                    @change="$emit('change-color', color)" />
+                                    <input
+                                        type="color"
+                                        v-model="color"
+                                        class="color-picker"
+                                        @click="$emit('click-color-picker')"
+                                        @change="$emit('change-color', color)"
+                                    />
                                     <span :style="{ backgroundColor: color }"></span>
                                 </div>
                                 <div class="column">
@@ -97,7 +102,13 @@ $width__sidebar: 20em;
                 <ul class="menu-list">
                     <li>
                         <a>
-                            <input type="range" min="1" max="20" v-model="weight" @change="$emit('change-weight', weight)" />
+                            <input
+                                type="range"
+                                min="1"
+                                max="20"
+                                v-model="weight"
+                                @change="$emit('change-weight', weight)"
+                            />
                             {{ weight }} px
                         </a>
                     </li>

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -69,7 +69,7 @@
                 <div class="background-circle" :style="{ backgroundColor: color }">
                     <font-awesome-icon class="awesome-icon zindex-2" icon="palette" />
                 </div>
-                <input class="color-picker" type="color" v-model="color" />
+                <input class="color-picker" type="color" v-model="color" @change="$emit('change-color', color)" />
             </button>
             <div
                 class="dropdown"

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -73,6 +73,7 @@
                     class="color-picker"
                     type="color"
                     v-model="color"
+                    @click="$emit('click-color-picker')"
                     @change="$emit('change-color', color)"
                 />
             </button>

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -34,10 +34,10 @@
 
 <template>
     <section class="drawing-container is-fullheight">
-        <DrawingTools @change-color="changeColor" @change-weight="changeWeight" />
+        <DrawingTools @click-color-picker="clickColorPicker" @change-color="changeColor" @change-weight="changeWeight" />
         <div class="body">
             <div class="canvas-container">
-                <Canvas :newColor="color" :newWeight="weight" />
+                <Canvas ref="canvas" :newColor="color" :newWeight="weight" />
             </div>
             <div class="button-container">
                 <div class="px-4">
@@ -68,6 +68,9 @@ export default {
         };
     },
     methods: {
+        clickColorPicker: function(){
+            this.$refs.canvas.stopPointer();
+        },
         changeColor: function (newColor) {
             this.color = newColor;
         },

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -68,8 +68,8 @@ export default {
         };
     },
     methods: {
-        changeColor: function(newColor){
-            this.color=newColor;
+        changeColor: function (newColor) {
+            this.color = newColor;
         },
         changeWeight: function (newWeight) {
             this.weight = newWeight;

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -8,14 +8,20 @@
 }
 </style>
 
-<template>    
-<section class="hero is-primary is-fullheight">
+<template>
+    <section class="hero is-primary is-fullheight">
         <div class="hero-body">
             <div class="canvas-container">
                 <Canvas ref="canvas" :newColor="color" :newWeight="weight" />
             </div>
         </div>
-        <DrawingTools @click-color-picker="clickColorPicker" @change-color="changeColor" @change-weight="changeWeight" @undo="undo" @redo="redo" />
+        <DrawingTools
+            @click-color-picker="clickColorPicker"
+            @change-color="changeColor"
+            @change-weight="changeWeight"
+            @undo="undo"
+            @redo="redo"
+        />
         <KeyUI />
     </section>
 </template>
@@ -39,7 +45,7 @@ export default {
         };
     },
     methods: {
-        clickColorPicker: function(){
+        clickColorPicker: function () {
             this.$refs.canvas.stopPointer();
         },
         changeColor: function (newColor) {

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -34,10 +34,10 @@
 
 <template>
     <section class="drawing-container is-fullheight">
-        <DrawingTools />
+        <DrawingTools @change-weight="changeWeight" />
         <div class="body">
             <div class="canvas-container">
-                <Canvas />
+                <Canvas :newWeight="weight" />
             </div>
             <div class="button-container">
                 <div class="px-4">
@@ -62,7 +62,14 @@ export default {
     components: { DrawingTools, Canvas },
     name: 'Drawing',
     data() {
-        return {};
+        return {
+            weight: 3,
+        };
+    },
+    methods: {
+        changeWeight: function (newWeight) {
+            this.weight = newWeight;
+        },
     },
 };
 </script>

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -34,10 +34,10 @@
 
 <template>
     <section class="drawing-container is-fullheight">
-        <DrawingTools @change-weight="changeWeight" />
+        <DrawingTools @change-color="changeColor" @change-weight="changeWeight" />
         <div class="body">
             <div class="canvas-container">
-                <Canvas :newWeight="weight" />
+                <Canvas :newColor="color" :newWeight="weight" />
             </div>
             <div class="button-container">
                 <div class="px-4">
@@ -63,10 +63,14 @@ export default {
     name: 'Drawing',
     data() {
         return {
+            color: '#000000',
             weight: 3,
         };
     },
     methods: {
+        changeColor: function(newColor){
+            this.color=newColor;
+        },
         changeWeight: function (newWeight) {
             this.weight = newWeight;
         },


### PR DESCRIPTION
### やったこと
weightボタンとcolorボタンを有効化しました。色と太さを変えて描画ができます。
実装方法がほとんど変わらない2つだったので、まとめてpushしました。

### 説明
DrawingToolコンポーネントでイベント発火→Drawingページで値を受け取る→Canvasコンポーネントに値を渡し、watchで値の変化を検知して処理を行う
大まかにこのような処理の流れになっています。
weight、colorはstoreで管理するべきでないプロパティだと思ったので、$emitとpropsで値の受け渡しを行っていますが、問題あればvuexを用いて実装します。

### やってほしいこと
- コードレビューをしていただきたいです。
- テストプレイでバグがないか見て頂きたいです。