### PR TITLE
Feat/drawing/etch a sketch/save load

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -244,8 +244,7 @@ export default {
             this.pointer.y = clickPos.y;
         },
         load() {
-            const data = localStorage.getItem('storage') || '[]';
-            this.savedItemList = JSON.parse(data);
+            this.loadDB();
             if(this.savedItemList.length >= 1){
                 const newPoint = this.savedItemList[this.savedItemList.length - 1].lastPoint;
                 this.pointer.x = newPoint.x;
@@ -261,9 +260,16 @@ export default {
             this.itemList.forEach((element) => {
                 this.savedItemList.push(element);
             });
-            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
+            this.saveDB();
             this.itemList = [];
             this.isAllSaved = true;
+        },
+        loadDB(){
+            const data = localStorage.getItem('storage') || '[]';
+            this.savedItemList = JSON.parse(data);
+        },
+        saveDB() {
+            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
         },
         reset() {
             this.savedItemList = [];

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -139,6 +139,14 @@ export default {
             if (key in keyMap) {
                 this.direction[keyMap[key]] = boolean;
             }
+            if(key=="z"){
+                console.log("saved");
+                this.save();
+            }
+            if(key=="x"){
+                console.log("loaded");
+                this.load();
+            }
         },
         keyDown(event) {
             this.keyEvent(event, true);
@@ -218,6 +226,14 @@ export default {
             this.pointer.x = clickPos.x;
             this.pointer.y = clickPos.y;
         },
+        load() {
+            const data = localStorage.getItem('storage') || '[]';
+            this.itemList = JSON.parse(data);
+        },
+
+        save() {
+            localStorage.setItem('storage', JSON.stringify(this.itemList));
+        }
     },
 };
 </script>

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -158,6 +158,10 @@ export default {
                 console.log('loaded');
                 this.load();
             }
+            if(key == 'c'){
+                console.log('reset');
+                this.reset();
+            }
         },
         keyDown(event) {
             this.keyEvent(event, true);
@@ -242,9 +246,11 @@ export default {
         load() {
             const data = localStorage.getItem('storage') || '[]';
             this.savedItemList = JSON.parse(data);
-            const newPoint = this.savedItemList[this.savedItemList.length - 1].lastPoint;
-            this.pointer.x = newPoint.x;
-            this.pointer.y = newPoint.y;
+            if(this.savedItemList.length >= 1){
+                const newPoint = this.savedItemList[this.savedItemList.length - 1].lastPoint;
+                this.pointer.x = newPoint.x;
+                this.pointer.y = newPoint.y;
+            }
             this.resetStack();
             this.itemList = [];
             this.setNewLine();
@@ -258,6 +264,10 @@ export default {
             localStorage.setItem('storage', JSON.stringify(this.savedItemList));
             this.itemList = [];
             this.isAllSaved = true;
+        },
+        reset() {
+            this.savedItemList = [];
+            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
         },
     },
 };

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -110,8 +110,8 @@ export default {
         document.removeEventListener('keydown', this.keyDown);
         document.removeEventListener('keyup', this.keyUp);
         clearInterval(this.timer);
-        if(this.isAllSaved)return;
-        if(window.confirm("変更をセーブしますか？"))this.save();
+        if (this.isAllSaved) return;
+        if (window.confirm('変更をセーブしますか？')) this.save();
     },
     watch: {
         newWeight: function () {
@@ -154,8 +154,8 @@ export default {
             if (key in keyMap) {
                 this.direction[keyMap[key]] = boolean;
             }
-            if(key=="x"){
-                console.log("loaded");
+            if (key == 'x') {
+                console.log('loaded');
                 this.load();
             }
         },
@@ -182,7 +182,7 @@ export default {
         setNewLine() {
             if (this.lineConfig.newLineFlag) return;
             this.lineConfig.newLineFlag = true;
-            if(this.itemList.length==0)return
+            if (this.itemList.length == 0) return;
             this.itemList[this.itemList.length - 1].lastPoint = {
                 x: this.pointer.x,
                 y: this.pointer.y,
@@ -202,7 +202,7 @@ export default {
             }
             if (this.lineConfig.newLineFlag) {
                 this.pushNewLine(lastPoint.x, lastPoint.y);
-                this.isAllSaved=false;
+                this.isAllSaved = false;
             }
             this.itemList[this.itemList.length - 1].line.points.push(
                 this.pointer.x,
@@ -242,23 +242,23 @@ export default {
         load() {
             const data = localStorage.getItem('storage') || '[]';
             this.savedItemList = JSON.parse(data);
-            const newPoint=this.savedItemList[this.savedItemList.length-1].lastPoint;
-            this.pointer.x=newPoint.x;
-            this.pointer.y=newPoint.y;
+            const newPoint = this.savedItemList[this.savedItemList.length - 1].lastPoint;
+            this.pointer.x = newPoint.x;
+            this.pointer.y = newPoint.y;
             this.resetStack();
-            this.itemList=[];
+            this.itemList = [];
             this.setNewLine();
-            this.isAllSaved=true;
+            this.isAllSaved = true;
         },
         save() {
             this.setNewLine();
-            this.itemList.forEach(element=>{
+            this.itemList.forEach((element) => {
                 this.savedItemList.push(element);
             });
             localStorage.setItem('storage', JSON.stringify(this.savedItemList));
-            this.itemList=[];
-            this.isAllSaved=true;
-        }
+            this.itemList = [];
+            this.isAllSaved = true;
+        },
     },
 };
 </script>

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -48,6 +48,7 @@ export default {
             savedItemList: [], //saveしたitemList。undoで消えない。
             itemStack: [],
             isUndoed: false,
+            isAllSaved: false,
             configKonva: {
                 width: 100,
                 height: 100,
@@ -103,11 +104,14 @@ export default {
          */
 
         window.addEventListener('resize', this.fitCanvas);
+        this.load();
     },
     destroyed: function () {
         document.removeEventListener('keydown', this.keyDown);
         document.removeEventListener('keyup', this.keyUp);
         clearInterval(this.timer);
+        if(this.isAllSaved)return;
+        if(window.confirm("変更をセーブしますか？"))this.save();
     },
     watch: {
         newWeight: function () {
@@ -149,10 +153,6 @@ export default {
             let key = event.key;
             if (key in keyMap) {
                 this.direction[keyMap[key]] = boolean;
-            }
-            if(key=="z"){
-                console.log("saved");
-                this.save();
             }
             if(key=="x"){
                 console.log("loaded");
@@ -202,6 +202,7 @@ export default {
             }
             if (this.lineConfig.newLineFlag) {
                 this.pushNewLine(lastPoint.x, lastPoint.y);
+                this.isAllSaved=false;
             }
             this.itemList[this.itemList.length - 1].line.points.push(
                 this.pointer.x,
@@ -247,6 +248,7 @@ export default {
             this.resetStack();
             this.itemList=[];
             this.setNewLine();
+            this.isAllSaved=true;
         },
         save() {
             this.setNewLine();
@@ -255,6 +257,7 @@ export default {
             });
             localStorage.setItem('storage', JSON.stringify(this.savedItemList));
             this.itemList=[];
+            this.isAllSaved=true;
         }
     },
 };

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -181,12 +181,13 @@ export default {
         },
         setNewLine() {
             if (this.lineConfig.newLineFlag) return;
+            this.lineConfig.newLineFlag = true;
+            if(this.itemList.length==0)return
             this.itemList[this.itemList.length - 1].lastPoint = {
                 x: this.pointer.x,
                 y: this.pointer.y,
             };
             console.log(this.itemList[this.itemList.length - 1]);
-            this.lineConfig.newLineFlag = true;
         },
         draw() {
             let lastPoint = { x: this.pointer.x, y: this.pointer.y };
@@ -240,10 +241,15 @@ export default {
         load() {
             const data = localStorage.getItem('storage') || '[]';
             this.savedItemList = JSON.parse(data);
-            this.itemList=[];
+            const newPoint=this.savedItemList[this.savedItemList.length-1].lastPoint;
+            this.pointer.x=newPoint.x;
+            this.pointer.y=newPoint.y;
             this.resetStack();
+            this.itemList=[];
+            this.setNewLine();
         },
         save() {
+            this.setNewLine();
             this.itemList.forEach(element=>{
                 this.savedItemList.push(element);
             });

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -4,17 +4,6 @@
     <div id="canvas" :style="{ height: '100%', width: '100%' }">
         <v-stage :config="configKonva" class="has-background-white" @click="movePointer">
             <v-layer>
-                <v-circle :config="pointer"></v-circle>
-                <v-line
-                    v-for="item in itemList"
-                    :key="item.id"
-                    :config="{
-                        points: item.line.points,
-                        lineCap: 'round',
-                        stroke: item.line.stroke,
-                        strokeWidth: item.line.strokeWidth,
-                    }"
-                ></v-line>
                 <v-line
                     v-for="item in savedItemList"
                     :key="item.id"
@@ -25,6 +14,17 @@
                         strokeWidth: item.line.strokeWidth,
                     }"
                 ></v-line>
+                <v-line
+                    v-for="item in itemList"
+                    :key="item.id"
+                    :config="{
+                        points: item.line.points,
+                        lineCap: 'round',
+                        stroke: item.line.stroke,
+                        strokeWidth: item.line.strokeWidth,
+                    }"
+                ></v-line>
+                <v-circle :config="pointer"></v-circle>
             </v-layer>
         </v-stage>
     </div>
@@ -57,8 +57,8 @@ export default {
                 x: 0,
                 y: 0,
                 radius: 3,
-                fill: 'white',
-                stroke: 'black',
+                fill: 'black',
+                stroke: 'gray',
                 strokeWidth: 4,
             },
             lineConfig: {
@@ -122,7 +122,7 @@ export default {
         },
         newColor: function () {
             this.lineConfig.color = this.newColor;
-            this.pointer.stroke = this.newColor;
+            this.pointer.fill = this.newColor;
             this.lineConfig.newLineFlag = true;
         },
     },

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -5,16 +5,6 @@
         <v-stage :config="configKonva" class="has-background-white" @click="movePointer">
             <v-layer>
                 <v-line
-                    v-for="item in savedItemList"
-                    :key="item.id"
-                    :config="{
-                        points: item.line.points,
-                        lineCap: 'round',
-                        stroke: item.line.stroke,
-                        strokeWidth: item.line.strokeWidth,
-                    }"
-                ></v-line>
-                <v-line
                     v-for="item in itemList"
                     :key="item.id"
                     :config="{
@@ -45,7 +35,6 @@ export default {
     data() {
         return {
             itemList: [], //{line: ラインオブジェクト, lastPoint: ライン最後の座標}
-            savedItemList: [], //saveしたitemList。undoで消えない。
             itemStack: [],
             isUndoed: false,
             isAllSaved: false,
@@ -245,35 +234,30 @@ export default {
         },
         load() {
             this.loadDB();
-            if(this.savedItemList.length >= 1){
-                const newPoint = this.savedItemList[this.savedItemList.length - 1].lastPoint;
+            if(this.itemList.length >= 1){
+                const newPoint = this.itemList[this.itemList.length - 1].lastPoint;
                 this.pointer.x = newPoint.x;
                 this.pointer.y = newPoint.y;
             }
             this.resetStack();
-            this.itemList = [];
             this.setNewLine();
             this.isAllSaved = true;
         },
         save() {
             this.setNewLine();
-            this.itemList.forEach((element) => {
-                this.savedItemList.push(element);
-            });
             this.saveDB();
-            this.itemList = [];
             this.isAllSaved = true;
         },
         loadDB(){
             const data = localStorage.getItem('storage') || '[]';
-            this.savedItemList = JSON.parse(data);
+            this.itemList = JSON.parse(data);
         },
         saveDB() {
-            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
+            localStorage.setItem('storage', JSON.stringify(this.itemList));
         },
         reset() {
-            this.savedItemList = [];
-            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
+            this.itemList = [];
+            localStorage.setItem('storage', JSON.stringify(this.itemList));
         },
     },
 };

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -15,6 +15,16 @@
                         strokeWidth: item.line.strokeWidth,
                     }"
                 ></v-line>
+                <v-line
+                    v-for="item in savedItemList"
+                    :key="item.id"
+                    :config="{
+                        points: item.line.points,
+                        lineCap: 'round',
+                        stroke: item.line.stroke,
+                        strokeWidth: item.line.strokeWidth,
+                    }"
+                ></v-line>
             </v-layer>
         </v-stage>
     </div>
@@ -35,6 +45,7 @@ export default {
     data() {
         return {
             itemList: [], //{line: ラインオブジェクト, lastPoint: ライン最後の座標}
+            savedItemList: [], //saveしたitemList。undoで消えない。
             itemStack: [],
             isUndoed: false,
             configKonva: {
@@ -228,11 +239,16 @@ export default {
         },
         load() {
             const data = localStorage.getItem('storage') || '[]';
-            this.itemList = JSON.parse(data);
+            this.savedItemList = JSON.parse(data);
+            this.itemList=[];
+            this.resetStack();
         },
-
         save() {
-            localStorage.setItem('storage', JSON.stringify(this.itemList));
+            this.itemList.forEach(element=>{
+                this.savedItemList.push(element);
+            });
+            localStorage.setItem('storage', JSON.stringify(this.savedItemList));
+            this.itemList=[];
         }
     },
 };

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -161,7 +161,7 @@ $width__sidebar: 20em;
                 <p class="menu-label">Save Options</p>
                 <ul class="menu-list">
                     <li>
-                        <a>
+                        <a @click="$emit('save')">
                             <font-awesome-icon
                                 class="mx-1 awesome-icon has-text-primary"
                                 icon="hdd"

--- a/src/components/NewDrawingButton.vue
+++ b/src/components/NewDrawingButton.vue
@@ -1,11 +1,7 @@
 <template>
     <button class="button is-rounded p-6">
-        <div class="control is-flex is-justify-content-around" :style="{'text-align': 'center'}">
-            <font-awesome-icon
-                icon="plus"
-                class="mx-1 awesome-icon has-text-primary"
-                size="3x"
-            />
+        <div class="control is-flex is-justify-content-around" :style="{ 'text-align': 'center' }">
+            <font-awesome-icon icon="plus" class="mx-1 awesome-icon has-text-primary" size="3x" />
             <p class="is-size-3 ml-2">New</p>
         </div>
     </button>

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -63,7 +63,7 @@ export default {
         },
         save: function () {
             this.$refs.canvas.save();
-        }
+        },
     },
 };
 </script>

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -21,6 +21,7 @@
             @change-weight="changeWeight"
             @undo="undo"
             @redo="redo"
+            @save="save"
         />
         <KeyUI />
     </section>
@@ -60,6 +61,9 @@ export default {
         redo: function () {
             this.$refs.canvas.redo();
         },
+        save: function () {
+            this.$refs.canvas.save();
+        }
     },
 };
 </script>

--- a/src/pages/Gallery.vue
+++ b/src/pages/Gallery.vue
@@ -6,7 +6,10 @@
                     <div class="box column is-four-fifths p-6 mt-6" style="height: 85vh">
                         <div class="columns is-flex-wrap-wrap">
                             <div class="column is-one-third">
-                                <div class="columns is-vcentered is-flex is-justify-content-center" style="height: 100%">
+                                <div
+                                    class="columns is-vcentered is-flex is-justify-content-center"
+                                    style="height: 100%"
+                                >
                                     <DrawingForm />
                                 </div>
                             </div>


### PR DESCRIPTION
### やったこと
- save,loadメソッドの実装
- save,loadメソッドの発火点の設置

### 説明
save,loadの実装に伴って、一度saveしたラインを再度redoさせないために、saveしたラインは別のリストに保管する仕様にしました。loadではこれを読み取っています。
また、キャンバスから離れる直前に保存していない変更があればセーブの確認を行うようにし、saveボタンを押したらセーブするようにしました。
キャンバスページへ戻ってきた際にセーブした内容はロードされます。また、一時的にxキーを押すことによってもロードを試すことができます。(後々削除予定)

### やり残し、改善点
- save時のデータの圧縮。(今の仕様的に直線は大幅に圧縮できそうです。)
- セーブできたかどうか、未保存の変更があるかどうかが視覚的に分かるといいなと思いました。
- localstorageDBを用いたデータの保存　最初にちょっと試してみたのですが、コンストラクタの呼び出しから躓いてしまい、後回しにしました。

### レビューしてほしい箇所
挙動テストをお願いします。
余裕があればコードレビューもお願いしたいです。

### 質問
やり残しの部分につきまして、取り組むべき優先度について意見をお伺いしたいです。