### PR TITLE
fix/router/drawing

### DIFF
--- a/src/components/DrawingBox.vue
+++ b/src/components/DrawingBox.vue
@@ -6,9 +6,11 @@
 
 <template>
     <div class="box container is-fluid" >
-        <figure class="image is-4by3 mb-2" @click="redirectToDrawingPage">
-            <img :src="drawing.imgUrl" />
-        </figure>
+        <router-link :to="`/drawing/${drawing.id}`">
+            <figure class="image is-4by3 mb-2" @click="redirectToDrawingPage" >
+                <img :src="drawing.imgUrl" />
+            </figure>
+        </router-link>
         <p class="title is-5 has-text-dark">{{ drawing.title }}</p>
         <div class="column is-one-fifths is-flex is-justify-content-flex-end">
             <font-awesome-icon
@@ -68,12 +70,6 @@ export default {
     },
     computed: mapGetters('drawing', ['isEtchASketchMode']),
     methods: {
-        redirectToDrawingPage() {
-            let path = '';
-            if (this.isEtchASketchMode) path = '/drawing/etchASketch';
-            else path = '/drawing';
-            this.$router.push(path);
-        },
         toggoleIsPublic() {
             this.isPublic = !this.isPublic;
         },

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -35,6 +35,7 @@ header {
 
             <div id="header-nav-items" class="navbar-menu" :class="{ 'is-active': isOpenMenu }">
                 <div class="navbar-start">
+                    <router-link to="/drawing/1" class="navbar-item sub-title">Drawing</router-link>
                     <router-link to="/gallery" class="navbar-item sub-title">Gallery</router-link>
                 </div>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -27,8 +27,8 @@ const routes = [
         component: Gallery,
     },
     {
-        path: '/drawing/etchASketch',
-        name: 'Drawing-EtchASketch',
+        path: '/drawing/:id',
+        name: 'Drawing',
         component: Drawing,
     },
     {


### PR DESCRIPTION
routerの修正を行いました

**理由**
- Drawingを直接リンクで共有したりする際に'/darwing'のようなリンクだけでは共有が不可能であるから。リンクに一意のidを埋め込むことで、直接リンクにアクセスした際にもロードができる。

**備考**
- #51 今回の開発範囲では影響はあまりないかもしれませんが、リンクを貼っておきます。
- Drawingのページを編集する権限のことを忘れていました。。今回はDrawingの作成者のみが編集できるようにします。
