### PR TITLE
refactor/drawing/vuex/color-weight

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -104,7 +104,7 @@ export default {
         if (window.confirm('変更をセーブしますか？')) this.save();
     },
     computed: {
-        ...mapState('drawing',['color','weight']),
+        ...mapState('drawing', ['color', 'weight']),
     },
     watch: {
         weight() {
@@ -144,7 +144,7 @@ export default {
                 console.log('loaded');
                 this.load();
             }
-            if(key == 'c'){
+            if (key == 'c') {
                 console.log('reset');
                 this.reset();
             }
@@ -232,7 +232,7 @@ export default {
         },
         load() {
             this.loadDB();
-            if(this.itemList.length >= 1){
+            if (this.itemList.length >= 1) {
                 const newPoint = this.itemList[this.itemList.length - 1].lastPoint;
                 this.pointer.x = newPoint.x;
                 this.pointer.y = newPoint.y;
@@ -245,9 +245,9 @@ export default {
             this.setNewLine();
             this.saveDB();
             this.isAllSaved = true;
-            console.log("saved");
+            console.log('saved');
         },
-        loadDB(){
+        loadDB() {
             const data = localStorage.getItem('storage') || '[]';
             this.itemList = JSON.parse(data);
         },

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -18,9 +18,9 @@
                     :config="{
                         x: pointer.x,
                         y: pointer.y,
-                        radius: selectedWeight / 2,
+                        radius: weight / 2,
                         fill: 'white',
-                        stroke: selectedColor,
+                        stroke: color,
                         strokeWidth: 4,
                     }"
                 ></v-circle>
@@ -30,6 +30,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 const velocityOfPointer = 2;
 const keyMap = {
     d: 'up',
@@ -103,15 +104,10 @@ export default {
         if (window.confirm('変更をセーブしますか？')) this.save();
     },
     computed: {
-        selectedColor: function () {
-            return this.$store.state.drawing.color;
-        },
-        selectedWeight: function () {
-            return this.$store.state.drawing.weight;
-        },
+        ...mapState('drawing',['color','weight']),
     },
     watch: {
-        selectedWeight() {
+        weight() {
             this.setNewLine();
         },
     },
@@ -166,8 +162,8 @@ export default {
             this.itemList.push({
                 line: {
                     points: [x, y],
-                    stroke: this.selectedColor,
-                    strokeWidth: this.selectedWeight,
+                    stroke: this.color,
+                    strokeWidth: this.weight,
                 },
                 lastPoint: {},
             });

--- a/src/components/DrawingBox.vue
+++ b/src/components/DrawingBox.vue
@@ -5,9 +5,9 @@
 </style>
 
 <template>
-    <div class="box container is-fluid" >
+    <div class="box container is-fluid">
         <router-link :to="`/drawing/${drawing.id}`">
-            <figure class="image is-4by3 mb-2" @click="redirectToDrawingPage" >
+            <figure class="image is-4by3 mb-2" @click="redirectToDrawingPage">
                 <img :src="drawing.imgUrl" />
             </figure>
         </router-link>

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -81,12 +81,12 @@ $width__sidebar: 20em;
                                 <div class="column">
                                     <input
                                         type="color"
-                                        v-model="color"
+                                        v-model="selectedColor"
                                         class="color-picker"
                                         @click="$emit('click-color-picker')"
                                         @change="
                                             $store.dispatch('drawing/changeColor', {
-                                                newColor: color,
+                                                newColor: selectedColor,
                                             })
                                         "
                                     />
@@ -108,9 +108,9 @@ $width__sidebar: 20em;
                                 type="range"
                                 min="1"
                                 max="20"
-                                v-model="weight"
+                                v-model="selectedWeight"
                                 @change="
-                                    $store.dispatch('drawing/changeWeight', { newWeight: weight })
+                                    $store.dispatch('drawing/changeWeight', { newWeight: selectedWeight })
                                 "
                             />
                             {{ weight }} px
@@ -171,6 +171,7 @@ $width__sidebar: 20em;
 </template>
 
 <script>
+import { mapState } from 'vuex';
 export default {
     name: 'DrawingTools',
     data() {
@@ -180,14 +181,15 @@ export default {
                 weight: false,
                 others: false,
             },
-            color: '',
-            weight: 0,
+            selectedColor: '',
+            selectedWeight: 0,
             isPublic: false,
         };
     },
+    computed: mapState('drawing',['color','weight']),
     mounted: function () {
-        this.color = this.$store.state.drawing.color;
-        this.weight = this.$store.state.drawing.weight;
+        this.selectedColor = this.color;
+        this.selectedWeight = this.weight;
     },
     methods: {
         toggleSideBar() {

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -110,7 +110,9 @@ $width__sidebar: 20em;
                                 max="20"
                                 v-model="selectedWeight"
                                 @change="
-                                    $store.dispatch('drawing/changeWeight', { newWeight: selectedWeight })
+                                    $store.dispatch('drawing/changeWeight', {
+                                        newWeight: selectedWeight,
+                                    })
                                 "
                             />
                             {{ weight }} px
@@ -186,7 +188,7 @@ export default {
             isPublic: false,
         };
     },
-    computed: mapState('drawing',['color','weight']),
+    computed: mapState('drawing', ['color', 'weight']),
     mounted: function () {
         this.selectedColor = this.color;
         this.selectedWeight = this.weight;

--- a/src/components/DrawingTools.vue
+++ b/src/components/DrawingTools.vue
@@ -84,7 +84,11 @@ $width__sidebar: 20em;
                                         v-model="color"
                                         class="color-picker"
                                         @click="$emit('click-color-picker')"
-                                        @change="$emit('change-color', color)"
+                                        @change="
+                                            $store.dispatch('drawing/changeColor', {
+                                                newColor: color,
+                                            })
+                                        "
                                     />
                                     <span :style="{ backgroundColor: color }"></span>
                                 </div>
@@ -105,7 +109,9 @@ $width__sidebar: 20em;
                                 min="1"
                                 max="20"
                                 v-model="weight"
-                                @change="$emit('change-weight', weight)"
+                                @change="
+                                    $store.dispatch('drawing/changeWeight', { newWeight: weight })
+                                "
                             />
                             {{ weight }} px
                         </a>
@@ -151,33 +157,15 @@ $width__sidebar: 20em;
             </aside>
         </div>
         <div class="sidebar-group" :class="{ 'is-closed': !isSidebarOpen }">
-            <button 
-                class="button m-1"
-                @click="toggleSideBar"
-            >
+            <button class="button m-1" @click="toggleSideBar">
                 <font-awesome-icon class="awesome-icon" icon="sliders-h" size="lg" />
             </button>
-            <button
-                class="button m-1"
-                @click="$emit('undo')"
-            >
-                <font-awesome-icon
-                    class="awesome-icon has-text-primary"
-                    icon="undo"
-                    size="lg"
-                />
+            <button class="button m-1" @click="$emit('undo')">
+                <font-awesome-icon class="awesome-icon has-text-primary" icon="undo" size="lg" />
             </button>
-            <button
-                class="button m-1"
-                @click="$emit('redo')"
-            >
-                <font-awesome-icon
-                    class="awesome-icon has-text-primary"
-                    icon="redo"
-                    size="lg"
-                />
+            <button class="button m-1" @click="$emit('redo')">
+                <font-awesome-icon class="awesome-icon has-text-primary" icon="redo" size="lg" />
             </button>
-            
         </div>
     </div>
 </template>
@@ -192,10 +180,14 @@ export default {
                 weight: false,
                 others: false,
             },
-            color: '#000000',
-            weight: 3,
+            color: '',
+            weight: 0,
             isPublic: false,
         };
+    },
+    mounted: function () {
+        this.color = this.$store.state.drawing.color;
+        this.weight = this.$store.state.drawing.weight;
     },
     methods: {
         toggleSideBar() {

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -12,16 +12,10 @@
     <section class="hero is-primary is-fullheight">
         <div class="hero-body">
             <div class="canvas-container">
-                <Canvas ref="canvas" :newColor="color" :newWeight="weight" />
+                <Canvas ref="canvas" />
             </div>
         </div>
-        <DrawingTools
-            @click-color-picker="clickColorPicker"
-            @change-color="changeColor"
-            @change-weight="changeWeight"
-            @undo="undo"
-            @redo="redo"
-        />
+        <DrawingTools @click-color-picker="clickColorPicker" @undo="undo" @redo="redo" />
         <KeyUI />
     </section>
 </template>
@@ -47,12 +41,6 @@ export default {
     methods: {
         clickColorPicker: function () {
             this.$refs.canvas.stopPointer();
-        },
-        changeColor: function (newColor) {
-            this.color = newColor;
-        },
-        changeWeight: function (newWeight) {
-            this.weight = newWeight;
         },
         undo: function () {
             this.$refs.canvas.undo();

--- a/src/pages/Drawing.vue
+++ b/src/pages/Drawing.vue
@@ -15,7 +15,12 @@
                 <Canvas ref="canvas" />
             </div>
         </div>
-        <DrawingTools @click-color-picker="clickColorPicker" @undo="undo" @redo="redo" @save="save" />
+        <DrawingTools
+            @click-color-picker="clickColorPicker"
+            @undo="undo"
+            @redo="redo"
+            @save="save"
+        />
         <KeyUI />
     </section>
 </template>

--- a/src/store/drawing.js
+++ b/src/store/drawing.js
@@ -1,13 +1,15 @@
 import Config from '../config';
-import { CHNAGE_MODE } from './types';
+import { CHNAGE_MODE, CHANGE_COLOR, CHANGE_WEIGHT } from './types';
 
 export default {
     namespaced: true,
     state: {
         mode: Config.mode.EtchASketch,
+        color: '#000000',
+        weight: 3,
     },
     getters: {
-        isEtchASketchMode: (state) => (state.mode == Config.mode.EtchASketch),
+        isEtchASketchMode: (state) => state.mode == Config.mode.EtchASketch,
     },
     actions: {
         changeMode({ commit }, { mode }) {
@@ -15,10 +17,22 @@ export default {
             commit(CHNAGE_MODE, mode);
             return true;
         },
+        changeColor({ commit }, { newColor }) {
+            commit(CHANGE_COLOR, newColor);
+        },
+        changeWeight({ commit }, { newWeight }) {
+            commit(CHANGE_WEIGHT, newWeight);
+        },
     },
     mutations: {
         [CHNAGE_MODE](state, mode) {
             state.mode = mode;
+        },
+        [CHANGE_COLOR](state, color) {
+            state.color = color;
+        },
+        [CHANGE_WEIGHT](state, weight) {
+            state.weight = Number(weight);
         },
     },
 };

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -2,3 +2,5 @@
  * Drawging
  */
 export const CHNAGE_MODE = 'CHNAGE_MODE';
+export const CHANGE_COLOR = 'CHANGE_COLOR';
+export const CHANGE_WEIGHT = 'CHANGE_WEIGHT';


### PR DESCRIPTION
### 本プルリクの目的
vuex周りのコードの書き方の共有、確認が主な目的です。

### やったこと
- ペンの色と太さをvuexで管理するよう変更しました。また、色と太さを変更するメソッドをvuex上に追加しました。
- 上で追加したvuexのstate,actionsを使って色と太さ関連のコードを書き替えました。
#75 の実装を部分的に行った形です。

### 確認してほしい事
コードレビューをお願いします。特にvuex関連のコード(drawing.js, vueコンポーネント内でのvuexの利用)の部分で不適切な書き方をしていないか確認を頂きたいです。

### 質問
redoなどのemitやrefを用いて実装している操作は全てvuexへ移行し、管理していくという認識で大丈夫でしょうか？また、それに伴って、vuexへ移行するメソッドに関わる変数(ポインター座標など)も全てvuexへ移行するという方針で実装していって良いでしょうか？

本プルリクで頂いたレビューを参考に、今後vuexへの移行を進めていきたいと思います！よろしくお願いいたします。